### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,7 +17,7 @@ html2text = "*"
 lsm-db = {git = "https://github.com/coleifer/python-lsm-db/"}
 python-levenshtein = "*"
 xxhash = "*"
-fuzzywuzzy = {extras = ["speedup"],version = "*"}
+rapidfuzz = "*"
 
 [requires]
 python_version = "3.7"

--- a/fuzz.py
+++ b/fuzz.py
@@ -9,7 +9,7 @@ from Levenshtein import distance
 from lsm import LSM
 from lsm import SEEK_LE, SEEK_GE
 from tuple import pack, unpack, strinc
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 
 HASH_SIZE = 2**10
@@ -114,8 +114,8 @@ def main():
             for _ in range(limit * 10):
                 packed = cursor.key()
                 key, label = unpack(packed)
-                d = fuzz.ratio(label, query)
-                if d >= 80:
+                d = fuzz.ratio(label, query, score_cutoff=80)
+                if d:
                     distances[label] = d
                 if not cursor.previous():
                     break
@@ -125,8 +125,8 @@ def main():
             for _ in range(limit * 10):
                 packed = cursor.key()
                 key, label = unpack(packed)
-                d = fuzz.ratio(label, query)
-                if d >= 80:
+                d = fuzz.ratio(label, query, score_cutoff=80)
+                if d:
                     distances[label] = d
                 cursor.next()
 

--- a/fw.py
+++ b/fw.py
@@ -1,6 +1,6 @@
 import sys
 import time
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 
 

--- a/typofix.py
+++ b/typofix.py
@@ -3,7 +3,7 @@ import sys
 from time import time
 from collections import Counter
 
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from fuzz import bbkh
 from lsm import LSM
 from lsm import SEEK_LE, SEEK_GE
@@ -40,8 +40,8 @@ for index, line in enumerate(f):
         for _ in range(limit * 10):
             packed = cursor.key()
             key, label = unpack(packed)
-            d = fuzz.ratio(label, query)
-            if d >= 70:
+            d = fuzz.ratio(label, query, score_cutoff=70)
+            if d:
                 distances[label] = d
             try:
                 cursor.previous()
@@ -53,8 +53,8 @@ for index, line in enumerate(f):
         for _ in range(limit * 10):
             packed = cursor.key()
             key, label = unpack(packed)
-            d = fuzz.ratio(label, query)
-            if d >= 70:
+            d = fuzz.ratio(label, query, score_cutoff=70)
+            if d:
                 distances[label] = d
             try:
                 cursor.next()


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy